### PR TITLE
Close menu on any outside click

### DIFF
--- a/LibDropdown-1.0/LibDropdown-1.0.lua
+++ b/LibDropdown-1.0/LibDropdown-1.0.lua
@@ -1182,8 +1182,12 @@ local t = {
 	LibStub("LibDropdown-1.0"):OpenAce3Menu(t)
 end]]
 
-WorldFrame:HookScript("OnMouseDown", function()
-	if openMenu then
-		openMenu = openMenu:Release()
+hooksecurefunc("UIDropDownMenu_HandleGlobalMouseEvent", function(button, event)
+	if openMenu and event == "GLOBAL_MOUSE_DOWN" and (button == "LeftButton" or button == "RightButton") then
+		for i = 0, frameCount - 1 do
+			if _G["LibDropdownFrame" .. i]:IsMouseOver() then return end
+		end
+
+		openMenu:Release()
 	end
 end)


### PR DESCRIPTION
Without this change, the menu doesn't close if you click other UI elements.

This new behaviour mimicks [UIDropdownMenu's behaviour](https://github.com/Gethe/wow-ui-source/blob/532edb9c5c2930dcc60a2f59c48f8fb414652be1/Interface/SharedXML/UIDropDownMenu.lua#L1275).