### PR TITLE
Fixed scaling issue to prevent cascading scales

### DIFF
--- a/LibDropdown-1.0/LibDropdown-1.0.lua
+++ b/LibDropdown-1.0/LibDropdown-1.0.lua
@@ -87,7 +87,7 @@ end
 new, del = lib.new, lib.del
 
 -- Make the frame match the tooltip
-local function InitializeFrame(frame, parent)
+local function InitializeFrame(frame)
 	if TooltipBackdropTemplateMixin then
 		frame.layoutType = GameTooltip.layoutType
 		if GameTooltip.layoutType then
@@ -104,9 +104,9 @@ local function InitializeFrame(frame, parent)
 			frame:SetBackdropBorderColor(GameTooltip:GetBackdropBorderColor())
 		end
 	end
-	
-	if not parent then
-		frame:SetScale(GameTooltip:GetScale())
+	frame:SetScale(GameTooltip:GetScale())
+	if (frame:GetEffectiveScale() ~= GameTooltip:GetEffectiveScale()) then -- consider applied SetIgnoreParentScale() on GameTooltip regarding scaling of the frame
+		frame:SetScale(frame:GetScale() * GameTooltip:GetEffectiveScale() / frame:GetEffectiveScale())
 	end
 end
 
@@ -615,7 +615,7 @@ end
 
 function AcquireFrame(parent, toplevel)
 	local f = tremove(framePool) or NewDropdownFrame()
-	InitializeFrame(f, parent) -- set the look of the frame
+	InitializeFrame(f) -- set the look of the frame
 	f.released = false
 	f.buttons = f.buttons or {}
 	f:SetParent(parent or UIParent)

--- a/LibDropdown-1.0/LibDropdown-1.0.lua
+++ b/LibDropdown-1.0/LibDropdown-1.0.lua
@@ -87,7 +87,7 @@ end
 new, del = lib.new, lib.del
 
 -- Make the frame match the tooltip
-local function InitializeFrame(frame)
+local function InitializeFrame(frame, parent)
 	if TooltipBackdropTemplateMixin then
 		frame.layoutType = GameTooltip.layoutType
 		if GameTooltip.layoutType then
@@ -104,7 +104,10 @@ local function InitializeFrame(frame)
 			frame:SetBackdropBorderColor(GameTooltip:GetBackdropBorderColor())
 		end
 	end
-	frame:SetScale(GameTooltip:GetScale())
+	
+	if not parent then
+		frame:SetScale(GameTooltip:GetScale())
+	end
 end
 
 local editBoxCount = 1
@@ -612,7 +615,7 @@ end
 
 function AcquireFrame(parent, toplevel)
 	local f = tremove(framePool) or NewDropdownFrame()
-	InitializeFrame(f) -- set the look of the frame
+	InitializeFrame(f, parent) -- set the look of the frame
 	f.released = false
 	f.buttons = f.buttons or {}
 	f:SetParent(parent or UIParent)


### PR DESCRIPTION
To prevent cascading scales calling `SetScale()` in `InitializeFrame()` is only necessary on the main frame of the dropdown.